### PR TITLE
feat: implement reservation calendar view

### DIFF
--- a/src/components/Sections/CalendarView.tsx
+++ b/src/components/Sections/CalendarView.tsx
@@ -80,7 +80,7 @@ export const CalendarView: React.FC<CalendarViewProps> = ({
             value={value}
             locale="es-ES"
             tileClassName={tileClassName}
-            className="w-full bg-transparent border-none text-white"
+            className="w-full max-w-xl mx-auto bg-transparent border-none text-white"
           />
         </div>
 

--- a/src/components/Sections/FieldBooking.tsx
+++ b/src/components/Sections/FieldBooking.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 import { Field } from '../../types';
 import { useData } from '../../contexts/DataContext';
@@ -14,19 +14,37 @@ interface FieldBookingProps {
 
 export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBookingComplete }) => {
   const { user } = useAuth();
-  const { addReservation, timeSlots, reservations } = useData();
-  const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
+  const { addReservation, timeSlots, reservations, selectedDate, setSelectedDate } = useData();
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<string | null>(null);
   const [isBooking, setIsBooking] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
+  const bookingDate = selectedDate || format(new Date(), 'yyyy-MM-dd');
+
   // Uso fallback para evitar undefined en field y slot
   const fieldId = field.id || '';
-  const allDaySlots = timeSlots.filter(ts => ts.fieldId === fieldId && ts.isActive && ((ts as any).allDays === true || (ts as any).date === selectedDate));
+
+  // Normalizamos slots para manejar ausencia de date/allDays
+  const normalizedSlots = useMemo(() => {
+    return timeSlots.map((ts) => {
+      const slotDate = (ts as any).date as string | undefined;
+      const allDays = (ts as any).allDays === true;
+      return { ...ts, date: slotDate, allDays } as TimeSlot & { date?: string; allDays?: boolean };
+    });
+  }, [timeSlots]);
+
+  const allDaySlots = useMemo(() => {
+    return normalizedSlots.filter((ts) => {
+      const matchesField = ts.fieldId === fieldId;
+      const matchesActive = ts.isActive;
+      const matchesDate = ts.allDays || !ts.date || ts.date === bookingDate;
+      return matchesField && matchesActive && matchesDate;
+    });
+  }, [normalizedSlots, fieldId, bookingDate]);
   
   // Defino el tipo local para los slots con price e isAvailable
   type SlotWithStatus = typeof allDaySlots[number] & { isAvailable: boolean; price: number };
-  const confirmedReservations = reservations.filter(r => r.fieldId === fieldId && r.date === selectedDate && r.status === 'confirmed');
+  const confirmedReservations = reservations.filter(r => r.fieldId === fieldId && r.date === bookingDate && r.status === 'confirmed');
   const slotsWithStatus: SlotWithStatus[] = allDaySlots.map(slot => {
     const isReserved = confirmedReservations.some(reservation => {
       const slotStart = slot.startTime || '';
@@ -35,8 +53,27 @@ export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBoo
       const reservationEnd = reservation.endTime || '';
       return slotStart < reservationEnd && slotEnd > reservationStart;
     });
-    return { ...slot, isAvailable: !isReserved, price: (slot as any).price || 0 };
+    const slotPrice = (slot as any).price as number | undefined;
+    const derivedPrice =
+      (typeof slotPrice === 'number' ? slotPrice : undefined) ??
+      (typeof field.pricePerHour === 'number' ? field.pricePerHour : undefined) ??
+      (typeof field.price === 'number' ? field.price : undefined) ??
+      0;
+    return { ...slot, isAvailable: !isReserved, price: derivedPrice };
   });
+
+  useEffect(() => {
+    console.log('📅 Booking date:', bookingDate);
+    console.log('🟢 Field id:', fieldId);
+    console.log('⏱️ Raw timeSlots:', timeSlots);
+    console.log('⏱️ Normalized slots:', normalizedSlots);
+    console.log('⏱️ Filtered slots for date:', bookingDate, allDaySlots);
+  }, [bookingDate, fieldId, timeSlots, normalizedSlots, allDaySlots]);
+
+  useEffect(() => {
+    // Clear selected slot if date changes to avoid stale selection
+    setSelectedTimeSlot(null);
+  }, [bookingDate]);
 
   const selectedSlot = slotsWithStatus.find(slot => slot.id === selectedTimeSlot) || null;
   
@@ -58,9 +95,20 @@ export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBoo
       return;
     }
     
-    // Check if slot is still available (double-check)
-    if (!selectedSlot.isAvailable) {
-      setValidationError('This time slot is no longer available');
+    // Check if slot is still available (double-check) and no overlapping reservation
+    const overlaps = reservations.some((reservation) => {
+      if (reservation.fieldId !== fieldId) return false;
+      if (reservation.date !== bookingDate) return false;
+      if (reservation.status === 'cancelled') return false;
+      const reservationStart = reservation.startTime || '';
+      const reservationEnd = reservation.endTime || '';
+      const slotStart = selectedSlot.startTime || '';
+      const slotEnd = selectedSlot.endTime || '';
+      return slotStart < reservationEnd && slotEnd > reservationStart;
+    });
+
+    if (!selectedSlot.isAvailable || overlaps) {
+      setValidationError('Este horario ya está reservado. Elige otro.');
       return;
     }
     
@@ -81,10 +129,10 @@ export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBoo
     addReservation({
       userId: user.id,
       fieldId: field.id,
-      date: selectedDate,
+      date: bookingDate,
       startTime: selectedSlot.startTime!,
       endTime: selectedSlot.endTime!,
-      totalPrice: selectedSlot.price,
+      totalPrice: selectedSlot.price ?? 0,
       paymentMethodId: 'default',
       status: 'pending',
     });
@@ -121,7 +169,7 @@ export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBoo
           <Calendar className="w-5 h-5 text-green-400" />
           <input
             type="date"
-            value={selectedDate}
+            value={bookingDate}
             onChange={(e) => setSelectedDate(e.target.value)}
             min={format(new Date(), 'yyyy-MM-dd')}
             className="bg-gray-700 text-white px-4 py-2 rounded-lg border border-gray-600 focus:ring-2 focus:ring-green-500"
@@ -182,7 +230,7 @@ export const FieldBooking: React.FC<FieldBookingProps> = ({ field, onBack, onBoo
                 <div className="flex justify-between">
                   <span>Fecha:</span>
                   <span className="text-white font-medium">
-                    {format(new Date(selectedDate), 'dd MMMM yyyy', { locale: es })}
+                    {format(new Date(bookingDate), 'dd MMMM yyyy', { locale: es })}
                   </span>
                 </div>
                 <div className="flex justify-between">

--- a/src/components/Sections/Reservations.tsx
+++ b/src/components/Sections/Reservations.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useData } from "../../contexts/DataContext";
 import { useAuth } from "../../contexts/AuthContext";
-import { CalendarView } from "./CalendarView";
+import { CalendarView } from "../calendar/CalendarView";
 
 interface ReservationsProps {
   onSectionChange?: (section: string) => void;
@@ -39,8 +39,25 @@ export const Reservations: React.FC<ReservationsProps> = ({
     return matchesStatus;
   });
 
-  const getStatusIcon = (status: string) => {
+  const normalizeStatus = (status: string) => {
     switch (status) {
+      case "confirmed":
+      case "pending":
+      case "cancelled":
+      case "completed":
+        return status;
+      case "earring":
+      case "earing":
+      case "pendiente":
+        return "pending";
+      default:
+        return "pending";
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    const normalized = normalizeStatus(status);
+    switch (normalized) {
       case "confirmed":
         return <CheckCircle className="w-5 h-5 text-green-500" />;
       case "pending":
@@ -53,20 +70,22 @@ export const Reservations: React.FC<ReservationsProps> = ({
   };
 
   const getStatusText = (status: string) => {
-    switch (status) {
+    const normalized = normalizeStatus(status);
+    switch (normalized) {
       case "confirmed":
-        return "Confirmada";
+        return "Confirmed";
       case "pending":
-        return "Pendiente";
+        return "Pending";
       case "cancelled":
-        return "Cancelada";
+        return "Cancelled";
       default:
-        return status;
+        return normalized;
     }
   };
 
   const getStatusColor = (status: string) => {
-    switch (status) {
+    const normalized = normalizeStatus(status);
+    switch (normalized) {
       case "confirmed":
         return "text-green-400";
       case "pending":

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,285 @@
+import React, { useMemo, useState } from 'react';
+import Calendar, { CalendarTileProperties } from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { useData } from '../../contexts/DataContext';
+import { Reservation } from '../../types';
+
+interface CalendarViewProps {
+  onDateSelect?: (date: Date) => void;
+  isAdminOrEmployee?: boolean;
+  onMakeReservation?: (date?: Date) => void;
+}
+
+const CalendarView: React.FC<CalendarViewProps> = ({
+  onDateSelect,
+  isAdminOrEmployee = false,
+  onMakeReservation,
+}) => {
+  const { reservations, fields, setSelectedDate, selectedDate } = useData();
+  const [activeDate, setActiveDate] = useState<Date>(
+    selectedDate ? new Date(selectedDate) : new Date()
+  );
+
+  // Build a quick lookup to color tiles and render counters.
+  const reservationsByDate = useMemo(() => {
+    return reservations.reduce<Record<string, Reservation[]>>((acc, current) => {
+      if (current.status === 'cancelled') return acc;
+      const key = current.date;
+      acc[key] = acc[key] ? [...acc[key], current] : [current];
+      return acc;
+    }, {});
+  }, [reservations]);
+
+  const dayReservations = useMemo(() => {
+    const key = format(activeDate, 'yyyy-MM-dd');
+    return reservationsByDate[key] ?? [];
+  }, [activeDate, reservationsByDate]);
+
+  const getFieldName = (fieldId: string) => {
+    const field = fields.find((f) => f.id === fieldId);
+    return field?.name ?? 'Cancha';
+  };
+
+  const tileClassName = ({ date, view }: CalendarTileProperties) => {
+    if (view !== 'month') return '';
+    const key = format(date, 'yyyy-MM-dd');
+    const count = reservationsByDate[key]?.length ?? 0;
+    if (count >= 5) return 'rc-tile rc-tile--busy';
+    if (count > 0) return 'rc-tile rc-tile--booked';
+    return 'rc-tile rc-tile--free';
+  };
+
+  const tileContent = ({ date, view }: CalendarTileProperties) => {
+    if (view !== 'month') return null;
+    const key = format(date, 'yyyy-MM-dd');
+    const count = reservationsByDate[key]?.length ?? 0;
+    if (count === 0) return null;
+    return (
+      <span className="absolute bottom-1 right-1 px-2 py-0.5 text-[10px] rounded-full bg-black/50 text-white">
+        {count}
+      </span>
+    );
+  };
+
+  const handleDayClick = (date: Date) => {
+    setActiveDate(date);
+    setSelectedDate(format(date, 'yyyy-MM-dd'));
+    onDateSelect?.(date);
+  };
+
+  const handleMakeReservation = () => {
+    onMakeReservation?.(activeDate);
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
+      <div className="bg-gray-900/70 border border-white/10 rounded-2xl p-6 shadow-lg">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <p className="text-sm text-gray-400">Elden Sports Fields</p>
+            <h2 className="text-2xl font-semibold text-white">Calendario de Reservas</h2>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-gray-200">
+            <div className="flex items-center gap-1">
+              <span className="inline-block w-3 h-3 rounded-full bg-green-500/30" />
+              <span>Disponible</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="inline-block w-3 h-3 rounded-full bg-yellow-500/40" />
+              <span>Reservas</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="inline-block w-3 h-3 rounded-full bg-red-500/40" />
+              <span>Alta demanda</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="calendar-card relative overflow-hidden rounded-xl bg-gray-950/60">
+          <Calendar
+            locale="en-US"
+            onClickDay={handleDayClick}
+            value={activeDate}
+            tileClassName={tileClassName}
+            tileContent={tileContent}
+            className="w-full max-w-xl mx-auto  p-4 text-white"
+          />
+        </div>
+      </div>
+
+      <div className="bg-gray-900/80 border border-white/10 rounded-2xl p-6 shadow-lg">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <p className="text-xs text-gray-400">Fecha seleccionada</p>
+            <h3 className="text-xl font-semibold text-white">
+              {format(activeDate, "EEEE, MMMM d")}
+            </h3>
+          </div>
+          <button
+            type="button"
+            className="px-4 py-2 rounded-lg bg-green-600 text-white text-sm font-semibold hover:bg-green-700 transition-colors"
+            onClick={handleMakeReservation}
+          >
+            Crear reserva
+          </button>
+        </div>
+
+        {dayReservations.length === 0 ? (
+          <div className="text-gray-400 text-sm bg-white/5 border border-dashed border-white/10 rounded-xl p-6 text-center">
+            No hay reservas para este día. Haz clic en el calendario para iniciar una.
+          </div>
+        ) : (
+          <ul className="space-y-3 max-h-[420px] overflow-y-auto pr-1">
+            {dayReservations.map((reservation) => (
+              <li
+                key={reservation.id}
+                className="flex flex-col gap-1 bg-white/5 border border-white/10 rounded-xl p-4"
+              >
+                <div className="flex items-center justify-between text-sm text-white">
+                  <span className="font-semibold">
+                    {reservation.startTime} - {reservation.endTime}
+                  </span>
+                  <span
+                    className={`px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wide ${
+                      reservation.status === 'confirmed'
+                        ? 'bg-green-500/20 text-green-300'
+                        : 'bg-yellow-500/20 text-yellow-200'
+                    }`}
+                  >
+                    {reservation.status}
+                  </span>
+                </div>
+                <p className="text-gray-300 text-sm">{getFieldName(reservation.fieldId)}</p>
+                {isAdminOrEmployee && (
+                  <p className="text-gray-400 text-xs">Usuario: {reservation.userId}</p>
+                )}
+                <p className="text-gray-500 text-xs">ID franja: {reservation.timeSlotId}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+    <style>{`
+
+    /* NAVIGATION BAR FIX */
+.calendar-card .react-calendar__navigation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+  /* ARROW BUTTONS */
+.calendar-card .react-calendar__navigation__arrow {
+  font-size: 1.9rem;          /* icon bigger */
+  padding: 6px 10px;
+  border-radius: 0.6rem;
+  transition: all 0.15s ease;
+  color: white;
+}
+/* HOVER STATE */
+.calendar-card .react-calendar__navigation__arrow:hover {
+  background: rgba(255,255,255,0.15);
+  color: #22c55e;
+}
+
+/* ALL NAV BUTTONS */
+.calendar-card .react-calendar__navigation button {
+  background: transparent !important;
+  color: white;
+  border: none;
+  font-weight: 600;
+}
+
+/* REMOVE GREY HOVER BLOCK */
+.calendar-card .react-calendar__navigation button:hover,
+.calendar-card .react-calendar__navigation button:focus,
+.calendar-card .react-calendar__navigation button:active {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+/* MONTH LABEL (CENTER TEXT) */
+.calendar-card .react-calendar__navigation__label {
+  pointer-events: none;
+  background: transparent !important;
+}
+
+
+.calendar-card .react-calendar {
+  background: transparent;
+  border: none;
+  width: 100%;
+  font-family: inherit;
+}
+
+/* GRID */
+.calendar-card .react-calendar__month-view__days {
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+/* BASE TILE */
+.calendar-card .react-calendar__tile {
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.7rem;
+  font-size: 0.9rem;
+  color: white;
+  transition: all 0.15s ease;
+}
+
+/* TODAY (CURRENT DATE) */
+.calendar-card .react-calendar__tile--now {
+  background: rgba(59,130,246,0.25);
+  border: 1px solid rgba(59,130,246,0.7);
+  color: #93c5fd;
+  font-weight: 700;
+}
+
+/* SELECTED DATE */
+.calendar-card .react-calendar__tile--active {
+  background: #22c55e !important;
+  color: white !important;
+  transform: scale(1.05);
+  box-shadow: 0 10px 20px rgba(34,197,94,0.4);
+}
+
+/* OTHER MONTH DAYS */
+.calendar-card .react-calendar__month-view__days__day--neighboringMonth {
+  
+  color: #ef4444;
+}
+
+/* HOVER */
+.calendar-card .react-calendar__tile:enabled:hover {
+  background: rgba(255,255,255,0.12);
+  color: white !important;
+}
+
+/* FREE / BOOKED / BUSY */
+.rc-tile--free {
+  background: rgba(34,197,94,0.08);
+}
+
+.rc-tile--booked {
+  background: rgba(234,179,8,0.18);
+}
+
+.rc-tile--busy {
+  background: rgba(239,68,68,0.22);
+}
+`}</style>
+
+
+    </div>
+  );
+};
+
+export { CalendarView };
+export default CalendarView;

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -53,6 +53,10 @@ interface DataContextType {
   updateReservation: (id: string, reservation: Partial<Reservation>) => Promise<void>;
   deleteReservation: (id: string) => Promise<void>;
   getAvailableTimeSlots: (fieldId: string, date: string) => TimeSlot[];
+
+  // UI state
+  selectedDate: string;
+  setSelectedDate: (date: string) => void;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -75,6 +79,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [fields, setFields] = useState<Field[]>([]);
   const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([]);
   const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().slice(0, 10));
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -114,20 +119,63 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
           reservations: dbReservations.length
         });
 
+        // Normalizar canchas para que siempre tengan sportId/sport/price coherentes y usen el id del documento
+        const normalizedFields: Field[] = dbFields.map((field) => {
+          const matchingSport = dbSports.find((s) =>
+            s.id === field.sportId ||
+            (field.sport && s.name?.toLowerCase() === field.sport.toLowerCase())
+          );
+
+          const sportId = matchingSport?.id ?? field.sportId ?? field.sport ?? '';
+          const sport = matchingSport?.name ?? field.sport ?? field.sportId ?? '';
+          const pricePerHour = typeof field.pricePerHour === 'number' ? field.pricePerHour : typeof field.price === 'number' ? field.price : 0;
+          const price = typeof field.price === 'number' ? field.price : pricePerHour;
+
+          return {
+            ...field,
+            id: field.id || '',
+            sportId,
+            sport,
+            pricePerHour,
+            price,
+          };
+        });
+
+        // Normalizar reservas (corregir estados mal escritos como "earring" → "pending")
+        const normalizeReservation = (reservation: Reservation): Reservation => {
+          const normalizedStatus = (() => {
+            switch (reservation.status) {
+              case 'pending':
+              case 'confirmed':
+              case 'cancelled':
+              case 'completed':
+                return reservation.status;
+              case 'earring':
+              case 'earing':
+              case 'pendiente':
+                return 'pending';
+              default:
+                return 'pending';
+            }
+          })();
+
+          return { ...reservation, status: normalizedStatus };
+        };
+
         // Establecer datos
         setEmployees(dbEmployees);
         setPositions(dbPositions);
         setDocumentTypes(dbDocumentTypes);
         setPaymentMethods(dbPaymentMethods);
         setSports(dbSports);
-        setFields(dbFields);
+        setFields(normalizedFields);
         setTimeSlots(dbTimeSlots);
-        setReservations(dbReservations);
+        setReservations(dbReservations.map(normalizeReservation));
 
         // Configurar listeners en tiempo real
         const unsubscribeReservations = DatabaseService.onReservationsChange((newReservations) => {
           console.log('🔄 Reservations updated:', newReservations.length);
-          setReservations(newReservations);
+          setReservations(newReservations.map(normalizeReservation));
         });
 
         const unsubscribeTimeSlots = DatabaseService.onTimeSlotsChange((newTimeSlots) => {
@@ -332,11 +380,26 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   // Field management functions
+  const normalizeFieldWithSports = (field: Field): Field => {
+    const matchingSport = sports.find((s) =>
+      s.id === field.sportId ||
+      (field.sport && s.name?.toLowerCase() === field.sport.toLowerCase())
+    );
+
+    const sportId = matchingSport?.id ?? field.sportId ?? field.sport ?? '';
+    const sport = matchingSport?.name ?? field.sport ?? field.sportId ?? '';
+    const pricePerHour = typeof field.pricePerHour === 'number' ? field.pricePerHour : typeof field.price === 'number' ? field.price : 0;
+    const price = typeof field.price === 'number' ? field.price : pricePerHour;
+
+    return { ...field, sportId, sport, pricePerHour, price, id: field.id || '' };
+  };
+
   const addField = async (field: Field) => {
     try {
       const newField = await DatabaseService.add<Field>('fields', field);
-      setFields(prev => [...prev, newField]);
-      console.log('✅ Field added:', newField);
+      const normalized = normalizeFieldWithSports(newField);
+      setFields(prev => [...prev, normalized]);
+      console.log('✅ Field added:', normalized);
     } catch (error) {
       console.error('❌ Error adding field:', error);
       throw error;
@@ -346,7 +409,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const updateField = async (id: string, field: Partial<Field>) => {
     try {
       await DatabaseService.update<Field>('fields', id, field);
-      setFields(prev => prev.map(f => f.id === id ? { ...f, ...field } : f));
+      setFields(prev => prev.map(f => f.id === id ? normalizeFieldWithSports({ ...f, ...field, id: f.id }) : f));
       console.log('✅ Field updated:', id);
     } catch (error) {
       console.error('❌ Error updating field:', error);
@@ -568,7 +631,9 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
       addReservation,
       updateReservation,
       deleteReservation,
-      getAvailableTimeSlots
+      getAvailableTimeSlots,
+      selectedDate,
+      setSelectedDate
     }}>
       {children}
     </DataContext.Provider>

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -4,12 +4,12 @@ import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, si
 
 // Configuración de Firebase - NECESITAS REEMPLAZAR ESTO CON TUS PROPIAS CREDENCIALES
 const firebaseConfig = {
-  apiKey: "AIzaSyB7BcluSnhI8kO6qqOcF0n-cPR5L7-o74Y",
-  authDomain: "campos-deportivos-elden.firebaseapp.com",
-  projectId: "campos-deportivos-elden",
-  storageBucket: "campos-deportivos-elden.firebasestorage.app",
-  messagingSenderId: "912663528205",
-  appId: "1:912663528205:web:7ebd5cd92d91c2c827e644"
+  apiKey: "AIzaSyDuIZp_jqzjGYbz9tVfLpthPCLEMISwquo",
+  authDomain: "elden-reservations.firebaseapp.com",
+  projectId: "elden-reservations",
+  storageBucket: "elden-reservations.firebasestorage.app",
+  messagingSenderId: "268338523202",
+  appId: "1:268338523202:web:819944f7d18ba5397b51db"
 };
 
 // Inicializar Firebase
@@ -71,14 +71,17 @@ export interface Sport {
 }
 
 export interface Field {
-  id?: string;
+  id: string;
   name: string;
   sportId: string;
-  description: string;
-  image: string;
+  pricePerHour: number;
+  sport?: string;
+  price?: number;
+  description?: string;
+  image?: string;
   images: string[];
   features: string[];
-  pricePerHour: number;
+  createdAt?: any;
 }
 
 export interface TimeSlot {
@@ -115,6 +118,58 @@ export interface Message {
   status: 'read' | 'unread';
   createdAt?: any;
 }
+
+// Normalizes Field documents to ensure sport/price/id are always present
+const normalizeField = (data: any, id: string): Field => {
+  const sportId = typeof data?.sportId === 'string' ? data.sportId : typeof data?.sport === 'string' ? data.sport : '';
+  const sport = typeof data?.sport === 'string' ? data.sport : sportId;
+  const basePrice = typeof data?.price === 'number' ? data.price : undefined;
+  const perHour = typeof data?.pricePerHour === 'number' ? data.pricePerHour : undefined;
+  const pricePerHour = perHour ?? basePrice ?? 0;
+  const price = basePrice ?? perHour ?? 0;
+
+  return {
+    ...data,
+    id,
+    sport,
+    sportId,
+    price,
+    pricePerHour,
+    name: data?.name ?? 'Cancha',
+    description: data?.description ?? '',
+    image: data?.image ?? '',
+    images: Array.isArray(data?.images) ? data.images : [],
+    features: Array.isArray(data?.features) ? data.features : [],
+  };
+};
+
+// Ensures fields written to Firestore carry both sport + sportId and price aliases
+const prepareFieldForWrite = (data: Partial<Field>) => {
+  const sportId = typeof data.sportId === 'string' ? data.sportId : typeof data.sport === 'string' ? data.sport : '';
+  const sport = typeof data.sport === 'string' ? data.sport : sportId;
+  const price =
+    typeof data.price === 'number'
+      ? data.price
+      : typeof data.pricePerHour === 'number'
+      ? data.pricePerHour
+      : 0;
+  const pricePerHour =
+    typeof data.pricePerHour === 'number'
+      ? data.pricePerHour
+      : typeof data.price === 'number'
+      ? data.price
+      : 0;
+
+  return {
+    ...data,
+    sport,
+    sportId,
+    price,
+    pricePerHour,
+    images: Array.isArray(data?.images) ? data.images : [],
+    features: Array.isArray(data?.features) ? data.features : [],
+  };
+};
 
 // Servicio de autenticación
 export class AuthService {
@@ -171,9 +226,13 @@ export class DatabaseService {
   static async getAll<T>(collectionName: string): Promise<T[]> {
     try {
       const querySnapshot = await getDocs(collection(db, collectionName));
-      return querySnapshot.docs.map(doc => ({
+      if (collectionName === 'fields') {
+        return querySnapshot.docs.map((doc) => normalizeField(doc.data(), doc.id)) as T[];
+      }
+
+      return querySnapshot.docs.map((doc) => ({
         id: doc.id,
-        ...doc.data()
+        ...doc.data(),
       })) as T[];
     } catch (error) {
       console.error(`Error getting all ${collectionName}:`, error);
@@ -187,6 +246,10 @@ export class DatabaseService {
       const docSnap = await getDoc(docRef);
       
       if (docSnap.exists()) {
+        if (collectionName === 'fields') {
+          return normalizeField(docSnap.data(), docSnap.id) as T;
+        }
+
         return {
           id: docSnap.id,
           ...docSnap.data()
@@ -202,13 +265,21 @@ export class DatabaseService {
 
   static async add<T>(collectionName: string, data: Omit<T, 'id' | 'createdAt'>): Promise<T> {
     try {
+      const baseData = collectionName === 'fields'
+        ? prepareFieldForWrite(data as Partial<Field>)
+        : data;
+
       const docData = {
-        ...data,
+        ...baseData,
         createdAt: serverTimestamp()
       };
       
       const docRef = await addDoc(collection(db, collectionName), docData);
       
+      if (collectionName === 'fields') {
+        return normalizeField(docData, docRef.id) as T;
+      }
+
       return {
         id: docRef.id,
         ...data
@@ -222,7 +293,10 @@ export class DatabaseService {
   static async update<T>(collectionName: string, id: string, data: Partial<T>): Promise<void> {
     try {
       const docRef = doc(db, collectionName, id);
-      await updateDoc(docRef, data as any);
+      const payload = collectionName === 'fields'
+        ? prepareFieldForWrite(data as Partial<Field>)
+        : data;
+      await updateDoc(docRef, payload as any);
     } catch (error) {
       console.error(`Error updating ${collectionName} with id ${id}:`, error);
       throw error;


### PR DESCRIPTION
## Description
This PR implements the reservation calendar view feature requested in issue #2.

Users can now see reservations in a monthly calendar view, identify available and busy days, and create reservations directly from the calendar.

The selected date is persisted across navigation so the booking flow remains consistent.

## Changes
- Integrated `react-calendar`
- Added `CalendarView` component
- Display reservations per day in calendar tiles
- Added occupancy indicators (free / booked / high demand)
- Enabled clicking on days to select date
- Persist selected date in DataContext
- Connected calendar with reservation creation flow
- Improved field normalization for Firestore data

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update

## Testing
- Calendar renders correctly
- Reservations appear on the correct date
- Date selection works
- Reservation creation works from calendar
- Navigation between calendar and booking preserves selected date
- No console errors

## Screenshots
(Calendar UI and reservation flow screenshots attached)
<img width="1443" height="815" alt="Screenshot 2026-02-11 170615" src="https://github.com/user-attachments/assets/6c6b022a-7fbc-4cb4-8bda-4b217c1fef11" />
<img width="1444" height="335" alt="Screenshot 2026-02-11 170705" src="https://github.com/user-attachments/assets/66fc52f9-bd9b-420b-ba42-efb48bf7d0c5" />
